### PR TITLE
Fix broken links and image paths

### DIFF
--- a/catering-landing-page.html
+++ b/catering-landing-page.html
@@ -4,9 +4,9 @@
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <title>Michelle Monet Catering - Artisanal Breads, French Pastries & Mexican Classics</title>
-    <link rel="preconnect" href="https:/fonts.googleapis.com">
-    <link rel="preconnect" href="https:/fonts.gstatic.com" crossorigin>
-    <link href="https:/fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;600;700&family=Montserrat:wght@300;400;500;600&display=swap" rel="stylesheet">
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Cormorant+Garamond:wght@300;400;600;700&family=Montserrat:wght@300;400;500;600&display=swap" rel="stylesheet">
     <style>
         * {
             margin: 0;
@@ -305,7 +305,7 @@
 </head>
 <body>
     <div class="whatsapp-banner">
-        <a href="https:/wa.me/5213314668654" target="_blank">
+        <a href="https://wa.me/5213314668654" target="_blank">
             <svg class="whatsapp-icon" viewBox="0 0 32 32" fill="currentColor">
                 <path d="M16 0C7.164 0 0 7.163 0 16c0 2.828.736 5.482 2.02 7.791L.695 30.49l7.013-1.833A15.926 15.926 0 0016 32c8.837 0 16-7.163 16-16S24.837 0 16 0zm0 29.333c-2.547 0-4.96-.714-7.013-1.953l-.502-.292-5.195 1.357 1.383-5.042-.32-.52A13.267 13.267 0 012.667 16C2.667 8.636 8.636 2.667 16 2.667S29.333 8.636 29.333 16 23.364 29.333 16 29.333z"/>
                 <path d="M23.547 19.547c-.373-.187-2.213-1.093-2.56-1.213-.347-.133-.6-.187-.853.187-.253.36-.987 1.213-1.213 1.467-.227.253-.453.28-.827.093-2.013-1.013-3.333-1.813-4.667-4.107-.36-.613.36-.573 1.04-1.907.107-.253.053-.467-.027-.653-.08-.187-.853-2.053-1.173-2.813-.307-.747-.613-.64-.853-.653-.213-.013-.467-.013-.72-.013s-.667.093-1.013.467c-.347.373-1.333 1.307-1.333 3.173s1.36 3.68 1.547 3.933c.187.253 2.667 4.08 6.467 5.72 2.387 1.04 3.32 1.147 4.52.973 1.133-.173 2.213-.893 2.533-1.76.32-.867.32-1.613.227-1.76-.093-.16-.333-.253-.707-.44z"/>
@@ -319,7 +319,7 @@
     </header>
 
     <div class="hero-section">
-        <img src="/1770775407567_D5BEE4F0-C29D-4F02-AB2A-3F3C79D2C400_1_201_a.jpeg" alt="Elegant chocolate cake with fresh berries">
+        <img src="D5BEE4F0-C29D-4F02-AB2A-3F3C79D2C400_1_201_a.jpeg" alt="Elegant chocolate cake with fresh berries">
         <div class="hero-overlay">
             <h1 class="hero-title">Michelle<br>Monet<br>Catering</h1>
         </div>
@@ -359,27 +359,27 @@
             <h2 class="section-title">Repostería Francesa</h2>
             <div class="gallery">
                 <div class="gallery-item">
-                    <img src="/1770775375472_9CA710FA-2E64-46D5-BB4A-812A0D304D8E_1_201_a.jpeg" alt="Pasta fresca con hierbas">
+                    <img src="9CA710FA-2E64-46D5-BB4A-812A0D304D8E_1_201_a.jpeg" alt="Pasta fresca con hierbas">
                     <div class="gallery-item-caption">Pasta Artesanal con Hierbas Frescas</div>
                 </div>
                 <div class="gallery-item">
-                    <img src="/1770775375473_F155BA3A-DB79-4F12-99F1-5C12553E8363_1_201_a.jpeg" alt="Pastel de monster azul">
+                    <img src="F155BA3A-DB79-4F12-99F1-5C12553E8363_1_201_a.jpeg" alt="Pastel de monster azul">
                     <div class="gallery-item-caption">Pastel Temático Creativo</div>
                 </div>
                 <div class="gallery-item">
-                    <img src="/1770775375474_259616E8-AFD5-4229-92C1-D106591BC722_1_201_a.jpeg" alt="Cookie yin yang">
+                    <img src="259616E8-AFD5-4229-92C1-D106591BC722_1_201_a.jpeg" alt="Cookie yin yang">
                     <div class="gallery-item-caption">Galletas Artesanales Yin Yang</div>
                 </div>
                 <div class="gallery-item">
-                    <img src="/1770775375474_76786C6C-9CCC-48D9-81AB-EAD206019F6E_1_201_a.jpeg" alt="Tarta de limón">
+                    <img src="76786C6C-9CCC-48D9-81AB-EAD206019F6E_1_201_a.jpeg" alt="Tarta de limón">
                     <div class="gallery-item-caption">Tarta de Limón con Granada</div>
                 </div>
                 <div class="gallery-item">
-                    <img src="/1770775375474_40292BFD-8D48-4C6E-9869-32993A6EF506_1_201_a.jpeg" alt="Galletas linzer">
+                    <img src="40292BFD-8D48-4C6E-9869-32993A6EF506_1_201_a.jpeg" alt="Galletas linzer">
                     <div class="gallery-item-caption">Galletas Linzer Tradicionales</div>
                 </div>
                 <div class="gallery-item">
-                    <img src="/1770775375474_25F21B65-4AA3-48F4-B2B2-2DD2B212BE56_1_201_a.jpeg" alt="Pan artesanal decorado">
+                    <img src="25F21B65-4AA3-48F4-B2B2-2DD2B212BE56_1_201_a.jpeg" alt="Pan artesanal decorado">
                     <div class="gallery-item-caption">Pan Artesanal con Decoración Única</div>
                 </div>
             </div>
@@ -389,19 +389,19 @@
             <h2 class="section-title">Panes y Delicias Artesanales</h2>
             <div class="gallery">
                 <div class="gallery-item">
-                    <img src="/1770775375475_2390B5B6-B5D8-4306-871D-754B031BC06E_1_201_a.jpeg" alt="Pan artesanal">
+                    <img src="2390B5B6-B5D8-4306-871D-754B031BC06E_1_201_a.jpeg" alt="Pan artesanal">
                     <div class="gallery-item-caption">Pan Artesanal Recién Horneado</div>
                 </div>
                 <div class="gallery-item">
-                    <img src="/1770775375475_166A82F7-DC05-4AC7-8AB8-A41024C1AC09_1_201_a.jpeg" alt="Bruschetta">
+                    <img src="166A82F7-DC05-4AC7-8AB8-A41024C1AC09_1_201_a.jpeg" alt="Bruschetta">
                     <div class="gallery-item-caption">Bruschetta Caprese Gourmet</div>
                 </div>
                 <div class="gallery-item">
-                    <img src="/1770775407566_866A8F93-AE85-44F9-AD28-4EF6A4BD1290_1_201_a.jpeg" alt="Niña cocinando">
+                    <img src="866A8F93-AE85-44F9-AD28-4EF6A4BD1290_1_201_a.jpeg" alt="Niña cocinando">
                     <div class="gallery-item-caption">Clases de Cocina para Niños</div>
                 </div>
                 <div class="gallery-item">
-                    <img src="/1770775407567_D5BEE4F0-C29D-4F02-AB2A-3F3C79D2C400_1_201_a.jpeg" alt="Pastel de chocolate">
+                    <img src="D5BEE4F0-C29D-4F02-AB2A-3F3C79D2C400_1_201_a.jpeg" alt="Pastel de chocolate">
                     <div class="gallery-item-caption">Pastel de Chocolate con Frutos del Bosque</div>
                 </div>
             </div>
@@ -412,7 +412,7 @@
             <p style="font-size: 1.2rem; margin-bottom: 1rem; color: #555;">
                 Contáctanos hoy mismo y cotiza tu evento
             </p>
-            <a href="https:/wa.me/5213314668654?text=Hola,%20me%20interesa%20cotizar%20un%20evento" class="cta-button" target="_blank">
+            <a href="https://wa.me/5213314668654?text=Hola,%20me%20interesa%20cotizar%20un%20evento" class="cta-button" target="_blank">
                 Cotizar por WhatsApp
             </a>
         </section>


### PR DESCRIPTION
Fixes:
- **URLs:** `https:/` → `https://` for Google Fonts and WhatsApp links
- **Images:** Update `src` to match repo filenames (remove numeric prefix)

Fonts and WhatsApp links work correctly; all gallery/hero images load.

Made with [Cursor](https://cursor.com)