### PR TITLE
Fix #7, #26, #18, #20, #21: padding and copy

### DIFF
--- a/index.html
+++ b/index.html
@@ -193,15 +193,15 @@
 
         .welcome-services {
             background: var(--white);
-            padding: 2rem 1rem;
-            margin: 1rem 0;
+            padding: 1.25rem 1rem;
+            margin: 0.75rem 0;
             border-radius: 12px;
             box-shadow: 0 4px 12px var(--shadow);
         }
 
         .welcome-services .section-head {
             text-align: center;
-            margin-bottom: 1.25rem;
+            margin-bottom: 0.75rem;
         }
 
         .welcome-services .section-head h2 {
@@ -213,10 +213,10 @@
         .welcome-services .welcome-text {
             text-align: center;
             font-size: 1.05rem;
-            line-height: 1.75;
+            line-height: 1.5;
             color: #555;
             max-width: 640px;
-            margin: 0 auto 1.5rem;
+            margin: 0 auto 1rem;
         }
 
         .welcome-services .services-lead {
@@ -228,14 +228,18 @@
         }
 
         .section {
-            margin: 2rem 0;
+            margin: 1rem 0;
         }
 
         .section-title {
             font-size: 1.8rem;
             color: var(--accent);
-            margin-bottom: 1.5rem;
+            margin-bottom: 1rem;
             text-align: center;
+        }
+
+        .elegirnos-list li {
+            margin-bottom: 0.25rem;
         }
 
         .gallery {
@@ -331,9 +335,9 @@
         .cta {
             background: var(--white);
             color: var(--primary);
-            padding: 3rem 1rem;
+            padding: 1.75rem 1rem;
             text-align: center;
-            margin: 2rem 0;
+            margin: 1rem 0;
             border-radius: 12px;
             border: 1px solid var(--primary);
         }
@@ -451,7 +455,7 @@
             <ul class="service-list">
                 <li class="service-item">
                     <strong>Entradas</strong>
-                    <span>Canapés, bruschettas y botanas para recibir a tus invitados.</span>
+                    <span>Humus, humus de betabel, dips (en español), tartas saladas, y sopas.</span>
                 </li>
                 <li class="service-item">
                     <strong>Guisados</strong>
@@ -459,11 +463,11 @@
                 </li>
                 <li class="service-item">
                     <strong>Postres</strong>
-                    <span>Pasteles, tartas, galletas y dulces artesanales.</span>
+                    <span>Pasteles, tartas, galletas, y brownies.</span>
                 </li>
                 <li class="service-item">
                     <strong>Panes artesanales</strong>
-                    <span>Pan recién horneado, baguettes y especialidades de panadería.</span>
+                    <span>Pan recién horneado de masa madre y especialidades saladas y dulces.</span>
                 </li>
             </ul>
         </section>
@@ -526,11 +530,13 @@
 
         <section class="section">
             <h2 class="section-title">¿Por Qué Elegirnos?</h2>
-            <div class="services">
-                <p style="font-size: 1.1rem; line-height: 2; color: #555;">
-                    Ingredientes de primera calidad • Recetas auténticas francesas y mexicanas • Presentación elegante y profesional • Puntualidad garantizada • Atención personalizada para cada evento • Servicio en Guadalajara, Zapopan, y alrededores
-                </p>
-            </div>
+            <ul class="elegirnos-list" style="font-size: 1.1rem; line-height: 1.6; color: #555; list-style: none; padding-left: 0;">
+                <li>Ingredientes de primera calidad</li>
+                <li>Recetas auténticas tradicionales</li>
+                <li>Presentación</li>
+                <li>Puntualidad</li>
+                <li>Atención personalizada</li>
+            </ul>
         </section>
     </main>
 


### PR DESCRIPTION
# Fix #7, #26, #18, #20, #21: Padding, copy, and menu text

## Summary
Single PR fulfilling five issues: padding/spacing, Por Qué Elegirnos content, and service-list copy for Entradas, Postres, and Panes artesanales.

---

### #7 — Revisit padding on subsections
- **Section spacing:** `.section` margin `2rem` → `1rem`; `.section-title` margin-bottom `1.5rem` → `1rem`
- **Welcome block:** padding `2rem 1rem` → `1.25rem 1rem`, margin `1rem` → `0.75rem`; section-head margin-bottom reduced
- **Welcome text:** line-height `1.75` → `1.5`, bottom margin reduced
- **CTA:** padding `3rem 1rem` → `1.75rem 1rem`, margin `2rem` → `1rem`
- **Por Qué Elegirnos:** line-height `2` → `1.6`; added `.elegirnos-list li` spacing

---

### #26 — Por Qué Elegirnos
- Replaced long paragraph with 5-item list:
  - Ingredientes de primera calidad
  - Recetas auténticas tradicionales
  - Presentación
  - Puntualidad
  - Atención personalizada
- Removed: “francesas y mexicanas”, “elegante y profesional”, “garantizada”, “para cada evento”, “Servicio en Guadalajara, Zapopan, y alrededores”
- Fixed typo: puntalidad → Puntualidad

---

### #18 — Entradas
- Service list text: **Humus, humus de betabel, dips (en español), tartas saladas, y sopas.**

---

### #20 — Postres
- Service list text: **Pasteles, tartas, galletas, y brownies.**

---

### #21 — Panes artesanales
- Removed baguettes and “especialidades de panadería”
- New text: **Pan recién horneado de masa madre y especialidades saladas y dulces.**

---

## Testing
- [ ] Sections look less cramped; spacing feels balanced
- [ ] Por Qué Elegirnos shows as a clean bullet list
- [ ] Entradas, Postres, and Panes artesanales show updated copy

Closes #7, Closes #26, Closes #18, Closes #20, Closes #21
