### PR TITLE
Fix #38 and #5: Update Instagram profile links

### DIFF
--- a/index.html
+++ b/index.html
@@ -407,7 +407,7 @@
             "availableLanguage": "Spanish"
         },
         "sameAs": [
-            "https://www.instagram.com/letters_from_the_kitchen"
+            "https://www.instagram.com/michelle_monet_catering/"
         ]
     }
     </script>
@@ -422,7 +422,7 @@
                 </svg>
                 <span>WhatsApp: +52 33 1466 8654</span>
             </a>
-            <a href="https://www.instagram.com/letters_from_the_kitchen" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
+            <a href="https://www.instagram.com/michelle_monet_catering/" target="_blank" rel="noopener noreferrer" aria-label="Instagram">
                 <svg class="contact-icon" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true">
                     <path d="M12 2.163c3.204 0 3.584.012 4.85.07 3.252.148 4.771 1.691 4.919 4.919.058 1.265.069 1.645.069 4.849 0 3.205-.012 3.584-.069 4.849-.149 3.225-1.664 4.771-4.919 4.919-1.266.058-1.644.07-4.85.07-3.204 0-3.584-.012-4.849-.07-3.26-.149-4.771-1.699-4.919-4.92-.058-1.265-.07-1.644-.07-4.849 0-3.204.013-3.583.07-4.849.149-3.227 1.664-4.771 4.919-4.919 1.266-.057 1.645-.069 4.849-.069zM12 0C8.741 0 8.333.014 7.053.072 2.695.272.273 2.69.073 7.052.014 8.333 0 8.741 0 12c0 3.259.014 3.668.072 4.948.2 4.358 2.618 6.78 6.98 6.98C8.333 23.986 8.741 24 12 24c3.259 0 3.668-.014 4.948-.072 4.354-.2 6.782-2.618 6.979-6.98.059-1.28.073-1.689.073-4.948 0-3.259-.014-3.667-.072-4.947-.196-4.354-2.617-6.78-6.979-6.98C15.668.014 15.259 0 12 0zm0 5.838a6.162 6.162 0 100 12.324 6.162 6.162 0 000-12.324zM12 16a4 4 0 110-8 4 4 0 010 8zm6.406-11.845a1.44 1.44 0 100 2.881 1.44 1.44 0 000-2.881z"/>
                 </svg>
@@ -444,7 +444,7 @@
             <div class="section-head">
                 <h2 id="welcome-heading">¡Bienvenido, Amigos!</h2>
                 <p class="welcome-text">
-                    Ofrecemos comida gourmet casera en Guadalajara y Zapopan. <a href="https://www.instagram.com/letters_from_the_kitchen" target="_blank" rel="noopener noreferrer">Síguenos en Instagram</a> para ver nuestro menú semanal especial y contáctanos para cotizar y ordenar.
+                    Ofrecemos comida gourmet casera en Guadalajara y Zapopan. <a href="https://www.instagram.com/michelle_monet_catering/" target="_blank" rel="noopener noreferrer">Síguenos en Instagram</a> para ver nuestro menú semanal especial y contáctanos para cotizar y ordenar.
                 </p>
             </div>
             <p class="services-lead">Desde entradas hasta postres, todo está hecho con ingredientes sanos de alta calidad y pasión por la gastronomía.</p>
@@ -537,7 +537,7 @@
     <footer class="footer">
         <h3 style="margin-bottom: 1rem;">Michelle Monet Catering</h3>
         <p>📍 Guadalajara, Jalisco, México</p>
-        <p>📱 <a href="https://wa.me/523314668654" target="_blank" rel="noopener noreferrer">WhatsApp: +52 33 1466 8654</a> · <a href="https://www.instagram.com/letters_from_the_kitchen" target="_blank" rel="noopener noreferrer">Instagram</a></p>
+        <p>📱 <a href="https://wa.me/523314668654" target="_blank" rel="noopener noreferrer">WhatsApp: +52 33 1466 8654</a> · <a href="https://www.instagram.com/michelle_monet_catering/" target="_blank" rel="noopener noreferrer">Instagram</a></p>
         <p style="margin-top: 1.5rem; font-size: 0.9rem;">
             © 2026 Michelle Monet Catering. Todos los derechos reservados.
         </p>


### PR DESCRIPTION
Fixes #38 and #5: Update Instagram profile links

## Summary
This PR updates all Instagram links for the site to use the official `michelle_monet_catering` profile and ensures the mobile/hero/footer links no longer point to a non-existent profile.

## Changes
- Replaced all `https://www.instagram.com/letters_from_the_kitchen` URLs in `index.html` with `https://www.instagram.com/michelle_monet_catering/`.
- Updated the JSON-LD `sameAs` entry so structured data also points at the new Instagram profile.
- Updated:
  - Header contact bar Instagram icon link
  - Welcome section “Síguenos en Instagram” link
  - Footer Instagram link

## Why
- **#38 IG updates**: Align all Instagram links with the new official profile.
- **#5 Instagram mobile link**: On mobile, the previous profile could return “profile doesn’t exist.” Using the single canonical profile URL fixes this for all devices.

## Testing
- [ ] Header Instagram icon opens `https://www.instagram.com/michelle_monet_catering/`.
- [ ] Welcome section “Síguenos en Instagram” link opens the same profile.
- [ ] Footer Instagram link opens the same profile.
- [ ] Instagram links work on mobile as well as desktop.

Closes #38
Closes #5
