### PR TITLE
Remove '(en español)' from Entradas service text

### DIFF
--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
             <ul class="service-list">
                 <li class="service-item">
                     <strong>Entradas</strong>
-                    <span>Humus, humus de betabel, dips, tartas saladas, y sopas.</span>
+                    <span>Humus, humus de betabel, tartas saladas, y sopas.</span>
                 </li>
                 <li class="service-item">
                     <strong>Guisados</strong>

--- a/index.html
+++ b/index.html
@@ -455,7 +455,7 @@
             <ul class="service-list">
                 <li class="service-item">
                     <strong>Entradas</strong>
-                    <span>Humus, humus de betabel, dips (en español), tartas saladas, y sopas.</span>
+                    <span>Humus, humus de betabel, dips, tartas saladas, y sopas.</span>
                 </li>
                 <li class="service-item">
                     <strong>Guisados</strong>


### PR DESCRIPTION
Removes the parenthetical "(en español)" from the Entradas service list so the line reads: _Humus, humus de betabel, dips, tartas saladas, y sopas._

Made with [Cursor](https://cursor.com)