### PR TITLE
Gallery: make grid responsive to avoid white space on large screens

### DIFF
--- a/index.html
+++ b/index.html
@@ -254,11 +254,7 @@
             }
         }
 
-        @media (min-width: 1024px) {
-            .gallery {
-                grid-template-columns: repeat(3, 1fr);
-            }
-        }
+        /* Kept at 2 columns on large screens so galleries with 4 or 2 items don't leave empty grid cells */
 
         .gallery-item {
             background: var(--white);


### PR DESCRIPTION
Fixes #45

Keeps the gallery at 2 columns from 640px upward instead of switching to 3 columns at 1024px, so there are no empty grid cells:
- First gallery (4 items): 2×2 grid
- Second gallery (2 items): 1 row of 2

Layout stays responsive: 1 column on small screens, 2 columns from 640px and up.

Made with [Cursor](https://cursor.com)